### PR TITLE
changed the bucket ACL from Bucket owner preferred to Bucket owner enforced

### DIFF
--- a/examples/decoupled-stacks/authservice-api-schema.json
+++ b/examples/decoupled-stacks/authservice-api-schema.json
@@ -1,0 +1,37 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+      "title": "central-api-managed-api-gw",
+      "version": "1.0.0",
+      "description": "Acme Central API GW",
+      "x-reconciler": {
+        "pathPrefix": "authservice"
+      }
+    },
+    "paths": {},
+    "components": {
+
+      "securitySchemes": {
+        "UserTokenAuth": {
+          "type": "apiKey",
+          "name": "authorization",
+          "in": "header",
+          "x-amazon-apigateway-authtype": "custom",
+          "x-amazon-apigateway-authorizer": {
+            "type": "request",
+            "identitySource": "method.request.header.authorization",
+            "identityValidationExpression": "Bearer .*",
+            "authorizerUri": "authserviceOperationUri",
+            "authorizerResultTtlInSeconds": 0
+          }
+        }
+      }
+    },
+    "x-amazon-apigateway-request-validators": {
+      "basic": {
+        "validateRequestBody": true,
+        "validateRequestParameters": true
+      }
+    },
+    "x-amazon-apigateway-request-validator": "basic"
+  }

--- a/examples/decoupled-stacks/authservice.ts
+++ b/examples/decoupled-stacks/authservice.ts
@@ -1,0 +1,113 @@
+import { App, Stack, StackProps } from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment'
+import { Function, InlineCode, Runtime } from 'aws-cdk-lib/aws-lambda'
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam'
+import { Bucket } from 'aws-cdk-lib/aws-s3'
+import * as conf from './config'
+// import  authApiSchema from './authservice-api-schema.json'
+
+
+
+class AuthServiceStack extends Stack {
+    
+    constructor(scope: Construct, id: string, props: StackProps) {
+        super(scope, id, props)
+
+        const reconcilerBucket = Bucket.fromBucketArn(this, 'SourceBucket',conf.reconcilerAPISchemaBucketArn );
+
+        // "Resource": "arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/dev/GET/"
+
+        //This should be on service side
+
+        const authserviceoperation = new Function(this, 'authserviceoperation', {
+            runtime: Runtime.NODEJS_18_X,
+            code: new InlineCode(
+                `
+        exports.handler = async function() {
+          return {
+            "principalId": "user",
+            "policyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "execute-api:Invoke",
+                  "Effect": "Allow"
+                  "Resource": arn:aws:execute-api:*:*:*/*/POST/demoservice/v1/demo "
+                }
+              ]
+            }
+          };
+        };
+        `),
+            handler: 'index.handler'
+        })
+
+        //Allow API gateway to call auth function as an authorizer
+        authserviceoperation.addPermission(`PermitAPIGWInvocationFor_auth}`, {
+            principal: new ServicePrincipal('apigateway.amazonaws.com'),
+            sourceArn: conf.centralAPIGW
+        })
+
+        const authserviceOperationUri = `arn:${Stack.of(this).partition}:apigateway:${Stack.of(this).region}:lambda:path/2015-03-31/functions/${authserviceoperation.functionArn}/invocations`
+   
+        const testauthserviceDefinition = {
+          "openapi": "3.0.3",
+          "info": {
+            "title": "central-api-managed-api-gw",
+            "version": "1.0.0",
+            "description": "Acme Central API GW",
+            "x-reconciler": {
+              "pathPrefix": "authservice"
+            }
+          },
+          "paths": {},
+          "components": {
+    
+            "securitySchemes": {
+              "UserTokenAuth": {
+                "type": "apiKey",
+                "name": "authorization",
+                "in": "header",
+                "x-amazon-apigateway-authtype": "custom",
+                "x-amazon-apigateway-authorizer": {
+                  "type": "request",
+                  "identitySource": "method.request.header.authorization",
+                  "identityValidationExpression": "Bearer .*",
+                  "authorizerUri": authserviceOperationUri,
+                  "authorizerResultTtlInSeconds": 0
+                }
+              }
+            }
+          },
+          "x-amazon-apigateway-request-validators": {
+            "basic": {
+              "validateRequestBody": true,
+              "validateRequestParameters": true
+            }
+          },
+          "x-amazon-apigateway-request-validator": "basic"
+        }
+
+        //Service can deploy their openapi schemas via BucketDeployment
+        new BucketDeployment(this, 'AuthAPISchema', {
+            destinationBucket: reconcilerBucket,
+            destinationKeyPrefix: 'authservice',
+            prune: false,
+            sources: [Source.jsonData('openapi.json', testauthserviceDefinition)],
+        })
+    }
+}
+
+
+const app = new App()
+
+new AuthServiceStack(app, 'AuthServiceStack', {
+    //Due to usage of Stack.of(scope).region, env has to be explicitly specifed
+    env: {
+        account: process.env.DEPLOY_ACCOUNT_ID,
+        region: process.env.DEPLOY_REGION
+    }
+})
+
+app.synth();

--- a/examples/decoupled-stacks/config.ts
+++ b/examples/decoupled-stacks/config.ts
@@ -1,3 +1,3 @@
-export const reconcilerMergedBucketArn="arn:aws:s3:::standalonereoncilerstack-reconcilermergedopenapid-1dl64grbno42y";
-export const reconcilerAPISchemaBucketArn= "arn:aws:s3:::standalonereoncilerstack-reconcileropenapidefinit-1drpnhtht049n";
-export const centralAPIGW="arn:aws:execute-api:ap-south-1:912469213006:1shn4k37a6/*/*/"
+export const reconcilerMergedBucketArn="arn:aws:s3:::sxxxxxxx";
+export const reconcilerAPISchemaBucketArn= "arn:aws:s3:::xxxx";
+export const centralAPIGW="arn:aws:execute-api:ap-south-1:cccccvvv"

--- a/examples/decoupled-stacks/config.ts
+++ b/examples/decoupled-stacks/config.ts
@@ -1,0 +1,3 @@
+export const reconcilerMergedBucketArn="arn:aws:s3:::standalonereoncilerstack-reconcilermergedopenapid-1dl64grbno42y";
+export const reconcilerAPISchemaBucketArn= "arn:aws:s3:::standalonereoncilerstack-reconcileropenapidefinit-1drpnhtht049n";
+export const centralAPIGW="arn:aws:execute-api:ap-south-1:912469213006:1shn4k37a6/*/*/"

--- a/examples/decoupled-stacks/demoService-api-schema.json
+++ b/examples/decoupled-stacks/demoService-api-schema.json
@@ -1,0 +1,245 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "demoservice",
+        "version": "1.0.0",
+        "description": "Affinidi demoservice Structure",
+        "x-reconciler": {
+            "pathPrefix": "demoservice"
+        }
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "security": [
+        {
+            "AwsSigV4": []
+        }
+    ],
+    "x-amazon-apigateway-request-validators": {
+        "basic": {
+            "validateRequestBody": true,
+            "validateRequestParameters": true
+        }
+    },
+    "x-amazon-apigateway-request-validator": "basic",
+    "components": {
+        "securitySchemes": {
+            "AwsSigV4": {
+                "type": "apiKey",
+                "name": "Authorization",
+                "in": "header",
+                "x-amazon-apigateway-authtype": "awsSigv4"
+            },
+            "ApiKey": {
+                "type": "apiKey",
+                "name": "x-api-key",
+                "in": "header",
+                "x-amazon-apigateway-api-key-source": "HEADER"
+            },
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            },
+            "UserTokenAuth": {
+                "type": "apiKey",
+                "name": "authorization",
+                "in": "header"
+            }
+        },
+        "headers": {},
+        "requestBodies": {
+            "DemoOperation": {
+                "description": "DemoOperation",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/DemoRequest"
+                        }
+                    }
+                }
+            }
+        },
+        "responses": {
+            "DemoOperationOK": {
+                "description": "Ok",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/DemoResponse"
+                        }
+                    }
+                }
+            },
+            "DemoOperationBadRequestError": {
+                "description": "BadRequestError",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/InvalidParameterError"
+                        }
+                    }
+                }
+            }
+        },
+        "schemas": {
+            "DemoRequest": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "DemoResponse": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "InvalidParameterError": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Some of the parameters are invalid",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": [
+                            "InvalidParameterError"
+                        ]
+                    },
+                    "message": {
+                        "type": "string",
+                        "enum": [
+                            "Invalid parameter: ${param}."
+                        ]
+                    },
+                    "httpStatusCode": {
+                        "type": "number",
+                        "enum": [
+                            400
+                        ]
+                    },
+                    "traceId": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "issue": {
+                                    "type": "string"
+                                },
+                                "field": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "issue"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "message",
+                    "httpStatusCode",
+                    "traceId"
+                ]
+            }
+        },
+        "examples": {}
+    },
+    "paths": {
+        "/v1/demo/sigv4": {
+            "post": {
+                "operationId": "demoOperationSigv4",
+                "security": [
+                    {
+                        "UserTokenAuth": []
+                    }
+                ],
+                "parameters": [],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/DemoOperation"
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/DemoOperationOK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/DemoOperationBadRequestError"
+                    }
+                },
+                "tags": [
+                    "demo"
+                ],
+                "x-amazon-apigateway-integration": {
+                    "httpMethod": "POST",
+                    "responses": {
+                        "default": {
+                            "statusCode": "200"
+                        }
+                    },
+                    "passthroughBehavior": "when_no_match",
+                    "contentHandling": "CONVERT_TO_TEXT",
+                    "type": "aws_proxy",
+                    "uri": "demoserviceOperationUri"
+                }
+            }
+        },
+        "/v1/demo/usertoken": {
+            "post": {
+                "operationId": "demoOperationUserToken",
+                "security": [
+                    {
+                        "UserTokenAuth": []
+                    }
+                ],
+                "parameters": [],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/DemoOperation"
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/DemoOperationOK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/DemoOperationBadRequestError"
+                    }
+                },
+                "tags": [
+                    "demo"
+                ],
+                "x-amazon-apigateway-integration": {
+                    "httpMethod": "POST",
+                    "responses": {
+                        "default": {
+                            "statusCode": "200"
+                        }
+                    },
+                    "passthroughBehavior": "when_no_match",
+                    "contentHandling": "CONVERT_TO_TEXT",
+                    "type": "aws_proxy",
+                    "uri": "demoserviceOperationUri"
+                }
+            }
+        }
+    }
+}

--- a/examples/decoupled-stacks/demoservice.ts
+++ b/examples/decoupled-stacks/demoservice.ts
@@ -1,92 +1,20 @@
-import { App, Aws, CfnOutput, Stack, StackProps } from 'aws-cdk-lib'
-import * as apigateway from 'aws-cdk-lib/aws-apigateway'
+import { App, Stack, StackProps } from 'aws-cdk-lib'
 import { Construct } from 'constructs'
-import { APIGWReconciler } from '../src/api-gw-reconciler'
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment'
 import { Function, InlineCode, Runtime } from 'aws-cdk-lib/aws-lambda'
 import { ServicePrincipal } from 'aws-cdk-lib/aws-iam'
+import { Bucket } from 'aws-cdk-lib/aws-s3'
+import * as conf from './config'
+// import  authApiSchema from './authservice-api-schema.json'
 
 
 
 class ReconcilerStack extends Stack {
-  public readonly reconciler: APIGWReconciler
-  public readonly api: apigateway.RestApi
 
   constructor(scope: Construct, id: string, props: StackProps) {
     super(scope, id, props)
 
-    //Create API gateway normally or via RefactorSpaces
-    this.api = new apigateway.RestApi(this, 'api', {})
-    this.api.root.addMethod('ANY')
-    const restApiReference = apigateway.RestApi.fromRestApiId(this, 'restApiReference', this.api.restApiId)
-
-
-    //Reconciler stack
-    this.reconciler = new APIGWReconciler(this, 'reconciler', {
-      restAPI: restApiReference,
-      securitySchemaPath: 'authservice/openapi.json',
-      apiDocPathPrefix: 'dev/api-docs',
-      apiDocSimpleAuthToken: '',
-      openapiHeader: {
-        info: {
-          title: 'test',
-          version: '1.0.2',
-          description: 'Central API GW test',
-        },
-        openapi: '',
-        paths: {},
-      },
-
-      allowedAccounts: [
-        {
-          allowedApiPathPrefix: 'authservice',
-          id: Aws.ACCOUNT_ID, //This should be account where *authservice* is deployed
-        },
-        {
-          allowedApiPathPrefix: 'demoservice',
-          id: Aws.ACCOUNT_ID, //This should be account where *authservice* is deployed
-        },
-      ],
-    })
-
-
-    // "Resource": "arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/dev/GET/"
-
-    //This should be on service side
-
-    const authserviceoperation = new Function(this, 'authserviceoperation', {
-      runtime: Runtime.NODEJS_18_X,
-      code: new InlineCode(
-        `
-        exports.handler = async function() {
-          return {
-            "principalId": "user",
-            "policyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Action": "execute-api:Invoke",
-                  "Effect": "Allow"
-                  "Resource": arn:aws:execute-api:*:*:*/*/POST/demoservice/v1/demo "
-                }
-              ]
-            }
-          };
-        };
-        `),
-      handler: 'index.handler'
-    })
-
-    //Allow API gateway to call auth function as an authorizer
-    authserviceoperation.addPermission(`PermitAPIGWInvocationFor_auth}`, {
-      principal: new ServicePrincipal('apigateway.amazonaws.com'),
-      sourceArn: this.api.arnForExecuteApi('authorizers', '/*', '/').replace(
-        '///authorizers',
-        '/authorizers',
-      ),
-    })
-
-    const authserviceOperationUri = `arn:${Stack.of(this).partition}:apigateway:${Stack.of(this).region}:lambda:path/2015-03-31/functions/${authserviceoperation.functionArn}/invocations`
+    const reconcilerBucket = Bucket.fromBucketArn(this, 'SourceBucket', conf.reconcilerAPISchemaBucketArn);
 
 
     const demooperation = new Function(this, 'demooperation', {
@@ -102,51 +30,12 @@ class ReconcilerStack extends Stack {
       handler: 'index.handler'
     })
 
-    //Allow  API gateway to call auth function for method execution
     demooperation.addPermission(`PermitAPIGWInvocationFor_demo`, {
       principal: new ServicePrincipal('apigateway.amazonaws.com'),
-      sourceArn: this.api.arnForExecuteApi('*'),
+      sourceArn: conf.centralAPIGW+"*",
     })
 
     const demoserviceOperationUri = `arn:${Stack.of(this).partition}:apigateway:${Stack.of(this).region}:lambda:path/2015-03-31/functions/${demooperation.functionArn}/invocations`
-
-    const testauthserviceDefinition = {
-      "openapi": "3.0.3",
-      "info": {
-        "title": "central-api-managed-api-gw",
-        "version": "1.0.0",
-        "description": "Acme Central API GW",
-        "x-reconciler": {
-          "pathPrefix": "authservice"
-        }
-      },
-      "paths": {},
-      "components": {
-
-        "securitySchemes": {
-          "UserTokenAuth": {
-            "type": "apiKey",
-            "name": "authorization",
-            "in": "header",
-            "x-amazon-apigateway-authtype": "custom",
-            "x-amazon-apigateway-authorizer": {
-              "type": "request",
-              "identitySource": "method.request.header.authorization",
-              "identityValidationExpression": "Bearer .*",
-              "authorizerUri": authserviceOperationUri,
-              "authorizerResultTtlInSeconds": 0
-            }
-          }
-        }
-      },
-      "x-amazon-apigateway-request-validators": {
-        "basic": {
-          "validateRequestBody": true,
-          "validateRequestParameters": true
-        }
-      },
-      "x-amazon-apigateway-request-validator": "basic"
-    }
 
 
     const testdemoserviceDefinition = {
@@ -395,51 +284,14 @@ class ReconcilerStack extends Stack {
       }
     }
 
-    //Service can deploy their openapi schemas via BucketDeployment
-    new BucketDeployment(this, 'testSchemaserviceAuth', {
-      destinationBucket: this.reconciler.openApiDefinitionBucket,
-      destinationKeyPrefix: 'authservice',
-      prune: false,
-      sources: [Source.jsonData('openapi.json', testauthserviceDefinition)],
-    })
 
     //Service can deploy their openapi schemas via BucketDeployment
     new BucketDeployment(this, 'testSchemaDemo', {
-      destinationBucket: this.reconciler.openApiDefinitionBucket,
+      destinationBucket: reconcilerBucket,
       destinationKeyPrefix: 'demoservice',
       prune: false,
       sources: [Source.jsonData('openapi.json', testdemoserviceDefinition)],
     })
-
-    new CfnOutput(this, 'curlJWT', {
-      value: `
-
-        Use this command to test: 
-
-        curl  https://${this.api.restApiId}.execute-api.ap-southeast-1.amazonaws.com/dev/demoservice/v1/demo/sigv4 \
-          -H "authorization: Bearer xxx"  \
-          -H 'Content-Type: application/json' \
-          -d'{"message": "Hello"}'
-        `
-    })
-
-    new CfnOutput(this, 'curl', {
-      value: `
-
-        Use this command to test:
-
-
-        curl --aws-sigv4 "aws:amz:ap-southeast-1:execute-api"  \
-        https://${this.api.restApiId}.execute-api.ap-southeast-1.amazonaws.com/dev/demoservice/v1/demo/usertoken   \
-        -H "x-amz-security-token: $AWS_SESSION_TOKEN" --user "$AWS_ACCESS_KEY_ID":"$AWS_SECRET_ACCESS_KEY"  \
-        -d '{"message": "Hello" }'
-        `
-    })
-
-    new CfnOutput(this, 'api-doc url', {
-      value: `https://${this.api.restApiId}.execute-api.ap-southeast-1.amazonaws.com/dev/api-docs/ui?token=`
-    })
-
   }
 
 

--- a/examples/decoupled-stacks/reconciler.ts
+++ b/examples/decoupled-stacks/reconciler.ts
@@ -1,0 +1,67 @@
+import { App, Aws, CfnOutput, Stack, StackProps } from 'aws-cdk-lib'
+import * as apigateway from 'aws-cdk-lib/aws-apigateway'
+import { Construct } from 'constructs'
+import { APIGWReconciler } from '../../src/api-gw-reconciler'
+import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment'
+import { Function, InlineCode, Runtime } from 'aws-cdk-lib/aws-lambda'
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam'
+
+
+
+class ReconcilerStack extends Stack {
+  public readonly reconciler: APIGWReconciler
+  public readonly api: apigateway.RestApi
+
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props)
+
+    //Create API gateway normally or via RefactorSpaces
+    this.api = new apigateway.RestApi(this, 'api', {})
+    this.api.root.addMethod('ANY')
+    const restApiReference = apigateway.RestApi.fromRestApiId(this, 'restApiReference', this.api.restApiId)
+
+
+    //Reconciler stack
+    this.reconciler = new APIGWReconciler(this, 'reconciler', {
+      restAPI: restApiReference,
+      securitySchemaPath: 'authservice/openapi.json',
+      apiDocPathPrefix: 'dev/api-docs',
+      apiDocSimpleAuthToken: '',
+      openapiHeader: {
+        info: {
+          title: 'Central API GW',
+          version: '1.0.0',
+          description: 'testing creation of only reconciler as standalone',
+        },
+        openapi: '',
+        paths: {},
+      },
+
+      allowedAccounts: [
+        {
+          allowedApiPathPrefix: 'authservice',
+          id: Aws.ACCOUNT_ID, //This should be account where *authservice* is deployed
+        },
+        {
+          allowedApiPathPrefix: 'demoservice',
+          id: Aws.ACCOUNT_ID, //This should be account where *authservice* is deployed
+        },
+      ],
+    })
+
+  }
+
+}
+
+
+const app = new App()
+
+new ReconcilerStack(app, 'StandAloneReoncilerStack', {
+  //Due to usage of Stack.of(scope).region, env has to be explicitly specifed
+  env: {
+    account: process.env.DEPLOY_ACCOUNT_ID,
+    region: process.env.DEPLOY_REGION
+  }
+})
+
+app.synth();

--- a/examples/new-rs-stack/authservice-api-schema.json
+++ b/examples/new-rs-stack/authservice-api-schema.json
@@ -1,0 +1,37 @@
+ {
+    "openapi": "3.0.3",
+    "info": {
+      "title": "central-api-managed-api-gw",
+      "version": "1.0.0",
+      "description": "Acme Central API GW",
+      "x-reconciler": {
+        "pathPrefix": "authservice"
+      }
+    },
+    "paths": {},
+    "components": {
+
+      "securitySchemes": {
+        "UserTokenAuth": {
+          "type": "apiKey",
+          "name": "authorization",
+          "in": "header",
+          "x-amazon-apigateway-authtype": "custom",
+          "x-amazon-apigateway-authorizer": {
+            "type": "request",
+            "identitySource": "method.request.header.authorization",
+            "identityValidationExpression": "Bearer .*",
+            "authorizerUri": "authserviceOperationUri",
+            "authorizerResultTtlInSeconds": 0
+          }
+        }
+      }
+    },
+    "x-amazon-apigateway-request-validators": {
+      "basic": {
+        "validateRequestBody": true,
+        "validateRequestParameters": true
+      }
+    },
+    "x-amazon-apigateway-request-validator": "basic"
+  }

--- a/examples/new-rs-stack/authservice.ts
+++ b/examples/new-rs-stack/authservice.ts
@@ -1,0 +1,70 @@
+import { App, Stack, StackProps } from 'aws-cdk-lib'
+import { Construct } from 'constructs'
+import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment'
+import { Function, InlineCode, Runtime } from 'aws-cdk-lib/aws-lambda'
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam'
+import { Bucket } from 'aws-cdk-lib/aws-s3'
+import * as conf from './config'
+import  authApiSchema from './authservice-api-schema.json'
+
+class AuthServiceStack extends Stack {
+    
+    constructor(scope: Construct, id: string, props: StackProps) {
+        super(scope, id, props)
+
+        const reconcilerBucket = Bucket.fromBucketArn(this, 'SourceBucket',conf.reconcilerAPISchemaBucketArn );
+
+        const authserviceoperation = new Function(this, 'authserviceoperation', {
+            runtime: Runtime.NODEJS_18_X,
+            code: new InlineCode(
+                `
+        exports.handler = async function() {
+          return {
+            "principalId": "user",
+            "policyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "execute-api:Invoke",
+                  "Effect": "Allow"
+                  "Resource": arn:aws:execute-api:*:*:*/*/POST/demoservice/v1/demo "
+                }
+              ]
+            }
+          };
+        };
+        `),
+            handler: 'index.handler'
+        })
+
+        //Allow API gateway to call auth function as an authorizer
+        authserviceoperation.addPermission(`PermitAPIGWInvocationFor_auth}`, {
+            principal: new ServicePrincipal('apigateway.amazonaws.com'),
+            sourceArn: conf.centralAPIGW
+        })
+
+        const authserviceOperationUri = `arn:${Stack.of(this).partition}:apigateway:${Stack.of(this).region}:lambda:path/2015-03-31/functions/${authserviceoperation.functionArn}/invocations`
+        const testauthserviceDefinition= authApiSchema;
+        testauthserviceDefinition.components.securitySchemes.UserTokenAuth['x-amazon-apigateway-authorizer'].authorizerUri=authserviceOperationUri;
+
+        new BucketDeployment(this, 'AuthAPISchema', {
+            destinationBucket: reconcilerBucket,
+            destinationKeyPrefix: 'authservice',
+            prune: false,
+            sources: [Source.jsonData('openapi.json', testauthserviceDefinition)],
+        })
+    }
+}
+
+
+const app = new App()
+
+new AuthServiceStack(app, 'AuthServiceStack', {
+    //Due to usage of Stack.of(scope).region, env has to be explicitly specifed
+    env: {
+        account: process.env.DEPLOY_ACCOUNT_ID,
+        region: process.env.DEPLOY_REGION
+    }
+})
+
+app.synth();

--- a/examples/new-rs-stack/config.ts
+++ b/examples/new-rs-stack/config.ts
@@ -1,6 +1,6 @@
-export const reconcilerMergedBucketArn="arn:aws:s3:::newrsreoncilerstack-reconcilermergedopenapidefini-luupn91k5zze";
-export const reconcilerAPISchemaBucketArn= "arn:aws:s3:::newrsreoncilerstack-reconcileropenapidefinitionbu-pk18na1kpkrs";
-export const centralAPIGW="arn:aws:execute-api:ap-southeast-1:912469213006:66fvzlp5oc/*/*/"
+export const reconcilerMergedBucketArn="arn:aws:s3:::newrsreoncilerstack-xxxxxx";
+export const reconcilerAPISchemaBucketArn= "arn:aws:s3:::newrsreoncilerstack-cfggghhghhjhj";
+export const centralAPIGW="arn:aws:execute-api:ap-southeast-1:jhhwsjhadsa8898s:66fvzlp5oc/*/*/"
 
-export const centralAPIGWId ="66fvzlp5oc";
-export const centralAPIGWrootResourceId= "rebpklsyce";
+export const centralAPIGWId ="777";
+export const centralAPIGWrootResourceId= "7887hgjk";

--- a/examples/new-rs-stack/config.ts
+++ b/examples/new-rs-stack/config.ts
@@ -1,0 +1,6 @@
+export const reconcilerMergedBucketArn="arn:aws:s3:::newrsreoncilerstack-reconcilermergedopenapidefini-luupn91k5zze";
+export const reconcilerAPISchemaBucketArn= "arn:aws:s3:::newrsreoncilerstack-reconcileropenapidefinitionbu-pk18na1kpkrs";
+export const centralAPIGW="arn:aws:execute-api:ap-southeast-1:912469213006:66fvzlp5oc/*/*/"
+
+export const centralAPIGWId ="66fvzlp5oc";
+export const centralAPIGWrootResourceId= "rebpklsyce";

--- a/examples/new-rs-stack/demoService-api-schema.json
+++ b/examples/new-rs-stack/demoService-api-schema.json
@@ -1,0 +1,245 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "demoservice",
+        "version": "1.0.0",
+        "description": "Affinidi demoservice Structure",
+        "x-reconciler": {
+            "pathPrefix": "demoservice"
+        }
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "security": [
+        {
+            "AwsSigV4": []
+        }
+    ],
+    "x-amazon-apigateway-request-validators": {
+        "basic": {
+            "validateRequestBody": true,
+            "validateRequestParameters": true
+        }
+    },
+    "x-amazon-apigateway-request-validator": "basic",
+    "components": {
+        "securitySchemes": {
+            "AwsSigV4": {
+                "type": "apiKey",
+                "name": "Authorization",
+                "in": "header",
+                "x-amazon-apigateway-authtype": "awsSigv4"
+            },
+            "ApiKey": {
+                "type": "apiKey",
+                "name": "x-api-key",
+                "in": "header",
+                "x-amazon-apigateway-api-key-source": "HEADER"
+            },
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            },
+            "UserTokenAuth": {
+                "type": "apiKey",
+                "name": "authorization",
+                "in": "header"
+            }
+        },
+        "headers": {},
+        "requestBodies": {
+            "DemoOperation": {
+                "description": "DemoOperation",
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/DemoRequest"
+                        }
+                    }
+                }
+            }
+        },
+        "responses": {
+            "DemoOperationOK": {
+                "description": "Ok",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/DemoResponse"
+                        }
+                    }
+                }
+            },
+            "DemoOperationBadRequestError": {
+                "description": "BadRequestError",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/InvalidParameterError"
+                        }
+                    }
+                }
+            }
+        },
+        "schemas": {
+            "DemoRequest": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "DemoResponse": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "InvalidParameterError": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Some of the parameters are invalid",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": [
+                            "InvalidParameterError"
+                        ]
+                    },
+                    "message": {
+                        "type": "string",
+                        "enum": [
+                            "Invalid parameter: ${param}."
+                        ]
+                    },
+                    "httpStatusCode": {
+                        "type": "number",
+                        "enum": [
+                            400
+                        ]
+                    },
+                    "traceId": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "issue": {
+                                    "type": "string"
+                                },
+                                "field": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "issue"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "message",
+                    "httpStatusCode",
+                    "traceId"
+                ]
+            }
+        },
+        "examples": {}
+    },
+    "paths": {
+        "/v1/demo/sigv4": {
+            "post": {
+                "operationId": "demoOperationSigv4",
+                "security": [
+                    {
+                        "UserTokenAuth": []
+                    }
+                ],
+                "parameters": [],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/DemoOperation"
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/DemoOperationOK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/DemoOperationBadRequestError"
+                    }
+                },
+                "tags": [
+                    "demo"
+                ],
+                "x-amazon-apigateway-integration": {
+                    "httpMethod": "POST",
+                    "responses": {
+                        "default": {
+                            "statusCode": "200"
+                        }
+                    },
+                    "passthroughBehavior": "when_no_match",
+                    "contentHandling": "CONVERT_TO_TEXT",
+                    "type": "aws_proxy",
+                    "uri": "demoserviceOperationUri"
+                }
+            }
+        },
+        "/v1/demo/usertoken": {
+            "post": {
+                "operationId": "demoOperationUserToken",
+                "security": [
+                    {
+                        "UserTokenAuth": []
+                    }
+                ],
+                "parameters": [],
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/DemoOperation"
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/DemoOperationOK"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/DemoOperationBadRequestError"
+                    }
+                },
+                "tags": [
+                    "demo"
+                ],
+                "x-amazon-apigateway-integration": {
+                    "httpMethod": "POST",
+                    "responses": {
+                        "default": {
+                            "statusCode": "200"
+                        }
+                    },
+                    "passthroughBehavior": "when_no_match",
+                    "contentHandling": "CONVERT_TO_TEXT",
+                    "type": "aws_proxy",
+                    "uri": "demoserviceOperationUri"
+                }
+            }
+        }
+    }
+}

--- a/examples/new-rs-stack/readme.md
+++ b/examples/new-rs-stack/readme.md
@@ -1,0 +1,5 @@
+export DEPLOY_ACCOUNT_ID="xxxxxxxxxx"  
+export DEPLOY_REGION=ap-southeast-1     
+
+cdk deploy --app 'npx ts-node reconciler.ts'
+

--- a/examples/new-rs-stack/reconciler.ts
+++ b/examples/new-rs-stack/reconciler.ts
@@ -1,0 +1,68 @@
+import { App, Aws, Stack, StackProps } from 'aws-cdk-lib'
+import * as apigateway from 'aws-cdk-lib/aws-apigateway'
+import { Construct } from 'constructs'
+import { APIGWReconciler } from '../../src/api-gw-reconciler'
+import * as conf from './config'
+
+
+class ReconcilerStack extends Stack {
+  public readonly reconciler: APIGWReconciler
+  //public readonly api: apigateway.RestApi
+
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props)
+
+
+    //Create API gateway normally or via RefactorSpaces
+    // this.api = new apigateway.RestApi(this, 'api', {})
+    //this.api.root.addMethod('ANY')
+    const restApiReference = apigateway.RestApi.fromRestApiAttributes(this, 'restApiReference', {
+      restApiId: conf.centralAPIGWId,
+      rootResourceId: conf.centralAPIGWrootResourceId
+    });
+    restApiReference.root.addMethod('ANY')
+
+    //Reconciler stack
+    this.reconciler = new APIGWReconciler(this, 'reconciler', {
+      restAPI: restApiReference,
+      securitySchemaPath: 'authservice/openapi.json',
+      apiDocPathPrefix: 'dev/api-docs',
+      apiDocSimpleAuthToken: '',
+      openapiHeader: {
+        info: {
+          title: 'Central API GW',
+          version: '1.0.0',
+          description: 'testing creation of only reconciler as standalone',
+        },
+        openapi: '',
+        paths: {},
+      },
+
+      allowedAccounts: [
+        {
+          allowedApiPathPrefix: 'authservice',
+          id: Aws.ACCOUNT_ID, //This should be account where *authservice* is deployed
+        },
+        {
+          allowedApiPathPrefix: 'demoservice',
+          id: Aws.ACCOUNT_ID, //This should be account where *authservice* is deployed
+        },
+      ],
+    })
+
+  }
+
+}
+
+
+const app = new App()
+
+new ReconcilerStack(app, 'NewRSReoncilerStack', {
+  //Due to usage of Stack.of(scope).region, env has to be explicitly specifed
+  env: {
+    account: process.env.DEPLOY_ACCOUNT_ID,
+    region: process.env.DEPLOY_REGION
+  }
+})
+
+app.synth();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,7 @@ export const S3_BUCKET_PROPS = {
   autoDeleteObjects: true,
   accessControl: BucketAccessControl.PRIVATE,
   blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
-  objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
+  objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
   enforceSSL: true,
 }
 


### PR DESCRIPTION
Fixes #
When a service account pushes the API schema, it controls the schema file and owner account can not read the file to merge the API. 

So changing to owner enforced so the owner account will get the access to all the files written to bucket